### PR TITLE
Integrate Docker Support for Web-Relay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Use an official Node.js runtime as the base image
+FROM node:16
+
+# Set the working directory inside the container
+WORKDIR /usr/src/app
+
+# Copy package.json and package-lock.json to the working directory
+COPY package*.json ./
+
+# Install the app dependencies
+RUN npm install
+
+# Copy the rest of the application code to the working directory
+COPY . .
+
+# The command to run the "web-relay" script
+CMD [ "npm", "run", "web-relay" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3"
+
+services:
+  web-relay:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000" # Assuming the relay runs on port 3000, adjust as needed
+

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "standard --fix --ignore example/*",
     "build": "rm -rf types && tsc",
     "fullcheck": "npm run lint && npm shrinkwrap && npm run build && npm run test",
+    "web-relay": "node example/browser/relay.js",
     "prepublishOnly": "npm run fullcheck"
   },
   "license": "MIT",


### PR DESCRIPTION
This PR introduces Docker support for the web-relay application. It adds both a `Dockerfile` and `docker-compose` configuration to streamline the deployment process.

**Dependencies:**
- This PR is dependent on "Add package-lock.json to Version Control and Pin Dependencies #20". Please ensure that PR is merged first to maintain consistency in our versioned dependencies.

**Resolves:**
- Closes #19: Request for Docker Configuration for Web-Relay.
