### PR TITLE
feat: add `/version` endpoint for last commit iInformation

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -8,6 +8,7 @@ const b4a = require('b4a')
 const lmdb = require('lmdb')
 const { URL } = require('url')
 const gitinfo = require('git-repo-info')()
+const LCL = require("last-commit-log");
 
 const Record = require('../record.js')
 const { HEADERS, HEADERS_NAMES } = require('../constants.js')
@@ -141,6 +142,11 @@ class Relay {
       return this._HEALTH_CHECK(req, res)
     }
 
+    // Check for the version endpoint
+    if (req.url === '/version' && req.method === 'GET') {
+      return this._VERSION(req, res);
+    }
+
     // Validate userID
     if (!validateUserID(req.url)) {
       res.writeHead(400, 'Invalid userID')
@@ -175,6 +181,20 @@ class Relay {
         res.writeHead(405, 'Method not allowed')
         res.end()
     }
+  }
+
+  /**
+   * Respond to version requests
+   *
+   * @param {http.IncomingMessage} req
+   * @param {http.ServerResponse} res
+   */
+  _VERSION(req, res) {
+    const lcl = new LCL();
+    const commit = lcl.getLastCommitSync();
+
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(commit));
   }
 
   /**

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12,6 +12,7 @@
         "@synonymdev/slashtags-url": "^1.0.0",
         "b4a": "1.6.4",
         "git-repo-info": "^2.1.1",
+        "last-commit-log": "^3.3.0",
         "level": "8.0.0",
         "lmdb": "2.8.4",
         "node-fetch": "2.6.12",
@@ -1002,6 +1003,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotgitconfig": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/dotgitconfig/-/dotgitconfig-1.1.2.tgz",
+      "integrity": "sha512-M+nUsYHJT2qs6bnYqotmO+1IQ09w3ZwLcX4MmbblaWN9C7ydDWM2xQLv22xfl4bUxienESi1GsZnZJPb8jslqQ==",
+      "dependencies": {
+        "ini": "^1.3.5"
       }
     },
     "node_modules/emoji-regex": {
@@ -2175,6 +2184,11 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
     "node_modules/internal-slot": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
@@ -2653,6 +2667,14 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/last-commit-log": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/last-commit-log/-/last-commit-log-3.3.0.tgz",
+      "integrity": "sha512-qYzhTltQvQ/mMIDWnG16KyUi79y4F5uEqHDDbAJm2HLuWgDuBhZ8g5PyWomYV0wsDQDuYcPWMQdJ91wsZOZ5NQ==",
+      "dependencies": {
+        "dotgitconfig": "^1.1.0"
       }
     },
     "node_modules/level": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@synonymdev/slashtags-url": "^1.0.0",
     "b4a": "1.6.4",
     "git-repo-info": "^2.1.1",
+    "last-commit-log": "^3.3.0",
     "level": "8.0.0",
     "lmdb": "2.8.4",
     "node-fetch": "2.6.12",


### PR DESCRIPTION
This pull request introduces a new endpoint `/version` to the server. When accessed, it returns information about the last commit made to the repository, including the commit hash, author, message, and date. This feature utilizes the `last-commit-log` npm package to retrieve the commit information.

### Changes:
- Added a new `_VERSION` method to the `Relay` class to handle requests to the `/version` endpoint.
- Updated the `_handle` method to include a condition for redirecting requests to the `/version` endpoint to the new `_VERSION` method.
- Included the `last-commit-log` package to fetch the last commit information.

This enhancement is crucial for users or systems that wish to monitor the version of the application currently deployed, especially in a development or staging environment where updates are frequent. It provides a programmatic means to fetch versioning information, facilitating automated tracking and management of application versions.
