### PR TITLE
fix: allow client to subscribe multiple times

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -49,7 +49,7 @@ class Client {
     /** @type {Map<string, ReturnType<setTimeout>>} */
     this._retryTimeouts = new Map()
     /** @type {Map<string, () => void>} */
-    this._supscriptions = new Map()
+    this._subscriptions = new Map()
 
     this._skipRecordVerification = opts._skipRecordVerification
 
@@ -179,8 +179,8 @@ class Client {
 
     const url = parsed.relay + '/subscribe/' + fullPath
 
-    if (this._supscriptions.has(url)) {
-      return this._supscriptions.get(url)
+    if (this._subscriptions.has(url)) {
+      return this._subscriptions.get(url)
     }
 
     const eventsource = new EventSource(url)
@@ -191,8 +191,12 @@ class Client {
       onupdate(value)
     }
 
-    const unsubscribe = () => eventsource.close()
-    this._supscriptions.set(url, unsubscribe)
+    const unsubscribe = () => {
+      eventsource.close()
+      this._subscriptions.delete(url)  
+    }
+
+    this._subscriptions.set(url, unsubscribe)
 
     return unsubscribe
   }
@@ -227,7 +231,7 @@ class Client {
 
   close () {
     this._retryTimeouts.forEach(clearTimeout)
-    this._supscriptions.forEach(unsubscribe => unsubscribe())
+    this._subscriptions.forEach(unsubscribe => unsubscribe())
     return this._store.close()
   }
 


### PR DESCRIPTION
Bitkit needs to be able to subscribe multiple times from different components with their own `onupdate` callback. Currently only the first `onupdate` is called (for the first component that subscribed). As long as Bitkit keeps track of subscriptions and unsubscribes properly there should be no redundant event listeners.