### PR TITLE
fix: xmlhttprequest module replacement

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
     "./lib/client/fetch.js": "./lib/client/fetch-browser.js",
     "./lib/client/default-storage.js": "./lib/client/default-storage-browser.js",
     "./lib/client/eventsource.js": "./lib/client/eventsource-browser.js",
-    "./lib/client/xmlhttprequest": "./lib/client/xmlhttprequest-browser.js"
+    "./lib/client/xmlhttprequest.js": "./lib/client/xmlhttprequest-browser.js"
   },
   "react-native": {
     "./index.js": "./lib/client/index.js",
     "./lib/client/fetch.js": "./lib/client/fetch-browser.js",
     "./lib/client/default-storage.js": "./lib/client/default-storage-browser.js",
     "./lib/client/eventsource.js": "./lib/client/eventsource.js",
-    "./lib/client/xmlhttprequest": "./lib/client/xmlhttprequest-browser.js"
+    "./lib/client/xmlhttprequest.js": "./lib/client/xmlhttprequest-browser.js"
   },
   "devDependencies": {
     "@types/node": "18.16.0",


### PR DESCRIPTION
Fixes react-native/browser not using it's own xmlhttprequest when using web-relay client.